### PR TITLE
chore/build script: pull libsodium source tarball from GitHub

### DIFF
--- a/rust_sodium-sys/build.rs
+++ b/rust_sodium-sys/build.rs
@@ -151,7 +151,8 @@ fn main() {
     // Download gz tarball
     let basename = "libsodium-".to_string() + VERSION;
     let gz_filename = basename.clone() + ".tar.gz";
-    let url = "https://download.libsodium.org/libsodium/releases/".to_string() + &gz_filename;
+    let url = "https://github.com/jedisct1/libsodium/releases/download/".to_string() + VERSION +
+              "/" + &gz_filename;
     let mut install_dir = get_install_dir();
     let mut source_dir = unwrap!(env::var("OUT_DIR")) + "/source";
     // Avoid issues with paths containing spaces by falling back to using /tmp


### PR DESCRIPTION
This is an attempt to avoid the frequent Curl SSL errors seen on Travis' OS X runs.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/rust_sodium/6)

<!-- Reviewable:end -->
