### PR TITLE
Fix rust-sodium-sys win build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,9 +11,9 @@ clone_depth: 50
 install:
   - ps: |
         $url = "https://github.com/maidsafe/QA/raw/master/Powershell%20Scripts/AppVeyor"
-        Start-FileDownload "$url/Install%20Rustup.ps1" -FileName "Install Rustup.ps1"
-        Start-FileDownload "$url/Build.ps1" -FileName "Build.ps1"
-        Start-FileDownload "$url/Run%20Tests.ps1" -FileName "Run Tests.ps1"
+        cmd /c curl -fsSL -o "Install Rustup.ps1" "$url/Install%20Rustup.ps1"
+        cmd /c curl -fsSL -o "Build.ps1" "$url/Build.ps1"
+        cmd /c curl -fsSL -o "Run Tests.ps1" "$url/Run%20Tests.ps1"
         . ".\Install Rustup.ps1"
 
 platform:

--- a/rust_sodium-sys/build.rs
+++ b/rust_sodium-sys/build.rs
@@ -66,8 +66,9 @@ fn main() {
     let gz_path = install_dir.clone() + "/" + &gz_filename;
     unwrap!(fs::create_dir_all(Path::new(&install_dir).join("lib")));
 
-    let command = "(New-Object System.Net.WebClient).DownloadFile(\"".to_string() + &url +
-                  "\", \"" + &gz_path + "\")";
+    let command = "([Net.ServicePointManager]::SecurityProtocol = 'Tls12') -and \
+                   ((New-Object System.Net.WebClient).DownloadFile(\""
+        .to_string() + &url + "\", \"" + &gz_path + "\"))";
     let mut download_cmd = Command::new("powershell");
     let download_output = download_cmd.arg("-Command")
         .arg(&command)
@@ -118,14 +119,14 @@ fn main() {
 
     // Get path to gcc in order to guess location of libpthread.a
     let mut lib_search_dirs = vec![Path::new(&install_dir).join("lib")];
-    let where_cmd = Command::new("where");
+    let mut where_cmd = Command::new("where");
     let where_output = where_cmd.arg(gcc::Config::new().get_compiler().path())
         .output()
         .unwrap_or_else(|error| {
             panic!("Failed to run where command: {}", error);
         });
     if !where_output.status.success() {
-        panic!("\n{:?}\n{}\n{}\n",
+        panic!("\n{:?}\n{}\n",
                String::from_utf8_lossy(&where_output.stdout),
                String::from_utf8_lossy(&where_output.stderr));
     }

--- a/rust_sodium-sys/build.rs
+++ b/rust_sodium-sys/build.rs
@@ -126,7 +126,8 @@ fn main() {
             panic!("Failed to run where command: {}", error);
         });
     if !where_output.status.success() {
-        panic!("\n{:?}\n{}\n",
+        panic!("\n{:?}\n{}\n{}\n",
+               where_cmd,
                String::from_utf8_lossy(&where_output.stdout),
                String::from_utf8_lossy(&where_output.stderr));
     }


### PR DESCRIPTION
Fix compile issues with build script in windows
Also fix the download file command used to download the lib sodium tarball.
