### PR TITLE
doc/links: fix several links in the documentation

### DIFF
--- a/rust_sodium-sys/src/crypto_pwhash_scryptsalsa208sha256.rs
+++ b/rust_sodium-sys/src/crypto_pwhash_scryptsalsa208sha256.rs
@@ -102,11 +102,12 @@ fn test_crypto_pwhash_scryptsalsa208sha256_str() {
                 as size_t)
     };
     assert!(ret_hash == 0);
-    let ret_verify = unsafe {
-        crypto_pwhash_scryptsalsa208sha256_str_verify(hashed_password.as_ptr(),
-                                                      password.as_ptr() as *const c_char,
-                                                      password.len() as c_ulonglong)
-    };
+    let ret_verify =
+        unsafe {
+            crypto_pwhash_scryptsalsa208sha256_str_verify(hashed_password.as_ptr(),
+                                                          password.as_ptr() as *const c_char,
+                                                          password.len() as c_ulonglong)
+        };
     assert!(ret_verify == 0);
 }
 #[test]

--- a/src/crypto/sign/mod.rs
+++ b/src/crypto/sign/mod.rs
@@ -1,12 +1,16 @@
 //! Public-key signatures
+//! 
+//! This module re-exports all members of the default signing scheme, currently
+//! [`ed25519`](ed25519/index.html), hence e.g. `sign` refers to
+//! [`ed25519::sign`](ed25519/fn.sign.html).
 //!
 //! # Security model
-//! The `sign()` function is designed to meet the standard
+//! The [`sign()`](ed25519/fn.sign.html) function is designed to meet the standard
 //! notion of unforgeability for a public-key signature scheme under
 //! chosen-message attacks.
 //!
 //! # Selected primitive
-//! `crypto::sign::sign` is `ed25519`, a signature scheme specified in
+//! [`crypto::sign::sign`](ed25519/fn.sign.html) is `ed25519`, a signature scheme specified in
 //! [Ed25519](http://ed25519.cr.yp.to/). This function is conjectured to meet the
 //! standard notion of unforgeability for a public-key signature scheme under
 //! chosen-message attacks.
@@ -43,4 +47,5 @@
 //! ```
 
 pub use self::ed25519::*;
+
 pub mod ed25519;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,48 +4,49 @@
 //! Cryptography library](http://nacl.cr.yp.to)
 //!
 //! For most users, if you want public-key (asymmetric) cryptography you should use
-//! the functions in `crypto::box_` for encryption/decryption.
+//! the functions in [`crypto::box_`](crypto/box_/index.html) for encryption/decryption.
 //!
 //! If you want secret-key (symmetric) cryptography you should be using the
-//! functions in `crypto::secretbox` for encryption/decryption.
+//! functions in [`crypto::secretbox`](crypto/secretbox/index.html) for encryption/decryption.
 //!
-//! For public-key signatures you should use the functions in `crypto::sign` for
-//! signature creation and verification.
+//! For public-key signatures you should use the functions in
+//! [`crypto::sign`](crypto/sign/index.html) for signature creation and verification.
 //!
 //! Unless you know what you're doing you most certainly don't want to use the
-//! functions in `crypto::scalarmult`, `crypto::stream`, `crypto::auth` and
-//! `crypto::onetimeauth`.
+//! functions in [`crypto::scalarmult`](crypto/scalarmult/index.html),
+//! [`crypto::stream`](crypto/stream/index.html), [`crypto::auth`](crypto/auth/index.html) and
+//! [`crypto::onetimeauth`](crypto/onetimeauth/index.html).
 //!
 //! ## Thread Safety
-//! All functions in this library are thread-safe provided that the `init()`
+//! All functions in this library are thread-safe provided that the [`init()`](fn.init.html)
 //! function has been called during program execution.
 //!
-//! If `init()` hasn't been called then all functions except the random-number
+//! If [`init()`](fn.init.html) hasn't been called then all functions except the random-number
 //! generation functions and the key-generation functions are thread-safe.
 //!
 //! # Public-key cryptography
-//!  `crypto::box_`
+//!  [`crypto::box_`](crypto/box_/index.html)
 //!
-//!  `crypto::sign`
+//!  [`crypto::sign`](crypto/sign/index.html)
 //!
 //! # Sealed boxes
-//!  `crypto::sealedox`
+//!  [`crypto::sealedbox`](crypto/sealedbox/index.html)
 //!
 //! # Secret-key cryptography
-//!  `crypto::secretbox`
+//!  [`crypto::secretbox`](crypto/secretbox/index.html)
 //!
-//!  `crypto::stream`
+//!  [`crypto::stream`](crypto/stream/index.html)
 //!
-//!  `crypto::auth`
+//!  [`crypto::auth`](crypto/auth/index.html)
 //!
-//!  `crypto::onetimeauth`
+//!  [`crypto::onetimeauth`](crypto/onetimeauth/index.html)
 //!
 //! # Low-level functions
-//!  `crypto::hash`
+//!  [`crypto::hash`](crypto/hash/index.html)
 //!
-//!  `crypto::verify`
+//!  [`crypto::verify`](crypto/verify/index.html)
 //!
-//!  `crypto::shorthash`
+//!  [`crypto::shorthash`](crypto/shorthash/index.html)
 
 #![doc(html_logo_url =
            "https://raw.githubusercontent.com/maidsafe/QA/master/Images/maidsafe_logo.png",


### PR DESCRIPTION
(I also ran rustfmt on this, though it panics in `crypto/scalarmult/curve25519.rs`.)