### PR TITLE
add link to Dev Forum and fix link to SAFE Network Forum

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ differences are:
 |:---:|:--------:|:-----:|:------:|:----:|
 |[![](http://meritbadge.herokuapp.com/rust_sodium)](https://crates.io/crates/rust_sodium)|[![Build Status](https://travis-ci.org/maidsafe/rust_sodium.svg?branch=master)](https://travis-ci.org/maidsafe/rust_sodium)|[![Build status](https://ci.appveyor.com/api/projects/status/kkgtqnx263xgk0c3/branch/master?svg=true)](https://ci.appveyor.com/project/MaidSafe-QA/rust-sodium/branch/master)|[![Coverage Status](https://coveralls.io/repos/maidsafe/rust_sodium/badge.svg)](https://coveralls.io/r/maidsafe/rust_sodium)|[![Stories in Ready](https://badge.waffle.io/maidsafe/rust_sodium.png?label=ready&title=Ready)](https://waffle.io/maidsafe/rust_sodium)|
 
-| [API Documentation - master branch](http://docs.maidsafe.net/rust_sodium/master) | [MaidSafe website](https://maidsafe.net) | [SAFE Network Forum](https://forum.safenetwork.io) |
-|:------:|:-------:|:-------:|
+| [API Docs - master branch](http://docs.maidsafe.net/rust_sodium/master) | [MaidSafe website](https://maidsafe.net) | [SAFE Dev Forum](https://forum.safedev.org) | [SAFE Network Forum](https://safenetforum.org) |
+|:------:|:-------:|:-------:|:-------:|
 
 ## License
 


### PR DESCRIPTION
As explained in [this topic](https://safenetforum.org/t/please-update-your-forum-bookmark-to-safenetforum-org/11358), the previous URL is no longer working. The new URL of the SAFE Network Forum is [safenetforum.org](https://safenetforum.org/).

I also added a link to the new [Dev Forum](https://forum.safedev.org/).