### PR TITLE
chore/build: update process used to download native libsodium

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ rust:
   - stable
   - nightly-2017-03-16
 sudo: false
+addons:
+  apt:
+    packages:
+      - libssl-dev
 branches:
   only:
     - master
@@ -45,4 +49,4 @@ script:
       );
     fi
 before_cache:
- - cargo prune
+  - cargo prune

--- a/README.md
+++ b/README.md
@@ -21,6 +21,47 @@ differences are:
 | [MaidSafe website](https://maidsafe.net) | [SAFE Dev Forum](https://forum.safedev.org) | [SAFE Network Forum](https://safenetforum.org) |
 |:----------------------------------------:|:-------------------------------------------:|:----------------------------------------------:|
 
+## Cross-Compiling
+
+### Cross-Compiling for ARM
+
+1. Install dependencies and toolchain:
+
+   ```sh
+   sudo apt update
+   sudo apt install build-essential gcc-arm-linux-gnueabihf libc6-armhf-cross libc6-dev-armhf-cross -y
+   rustup target add armv7-unknown-linux-gnueabihf
+   ```
+
+1. Add the following to a [.cargo/config file](http://doc.crates.io/config.html):
+
+   ```
+   [target.armv7-unknown-linux-gnueabihf]
+   linker = "arm-linux-gnueabihf-gcc"
+   ```
+
+1. Build by running:
+
+   ```sh
+   cargo build --release --target armv7-unknown-linux-gnueabihf
+   ```
+
+### Cross-Compiling for 32-bit Linux
+
+1. Install dependencies and toolchain:
+
+   ```sh
+   sudo apt update
+   sudo apt install build-essential gcc-multilib -y
+   rustup target add i686-unknown-linux-gnu
+   ```
+
+1. Build by running:
+
+   ```sh
+   cargo build --release --target i686-unknown-linux-gnu
+   ```
+
 ## License
 
 Licensed under either of

--- a/rust_sodium-sys/Cargo.toml
+++ b/rust_sodium-sys/Cargo.toml
@@ -18,10 +18,11 @@ rand = "~0.3.14"
 unwrap = "~1.1.0"
 
 [build-dependencies]
-flate2 = { version = "~0.2.14", optional = true }
-gcc = { version = "~0.3.35", optional = true }
-pkg-config = { version = "~0.3.8", optional = true }
-tar = { version = "~0.4.8", optional = true }
+flate2 = { version = "~0.2.17", optional = true }
+gcc = { version = "~0.3.45", optional = true }
+pkg-config = { version = "~0.3.9", optional = true }
+reqwest = { version = "~0.5.0", optional = true }
+tar = { version = "~0.4.11", optional = true }
 unwrap = "~1.1.0"
 
 [lib]
@@ -29,4 +30,4 @@ path = "lib.rs"
 
 [features]
 default = ["pkg-config"]
-get-libsodium = ["flate2", "gcc", "tar"]
+get-libsodium = ["flate2", "gcc", "reqwest", "tar"]

--- a/rust_sodium-sys/src/init_with_rng.rs
+++ b/rust_sodium-sys/src/init_with_rng.rs
@@ -144,7 +144,9 @@ fn test_seeded_init_with_rng() {
     assert_eq!(expected_public_key, public_key);
     assert_eq!(expected_private_key, private_key);
 
-    let child1 = unwrap!(Builder::new().name("child1".to_string()).spawn(move || {
+    let child1 = unwrap!(Builder::new()
+                             .name("child1".to_string())
+                             .spawn(move || {
         let mut public_key = [0u8; crypto_box_curve25519xsalsa20poly1305_PUBLICKEYBYTES];
         let mut private_key = [0u8; crypto_box_curve25519xsalsa20poly1305_SECRETKEYBYTES];
         unsafe {
@@ -155,7 +157,9 @@ fn test_seeded_init_with_rng() {
         assert_eq!(expected_public_key, public_key);
         assert_eq!(expected_private_key, private_key);
     }));
-    let child2 = unwrap!(Builder::new().name("child2".to_string()).spawn(move || {
+    let child2 = unwrap!(Builder::new()
+                             .name("child2".to_string())
+                             .spawn(move || {
         let mut public_key = [0u8; crypto_box_curve25519xsalsa20poly1305_PUBLICKEYBYTES];
         let mut private_key = [0u8; crypto_box_curve25519xsalsa20poly1305_SECRETKEYBYTES];
         unsafe {

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -69,7 +69,8 @@ fn main() {
     cfg.type_name(|s, _| s.to_string());
     cfg.skip_signededness(|s| s == "crypto_auth_hmacsha512256_state");
     cfg.skip_const(|s| {
-        s.ends_with("_PRIMITIVE") || s == "crypto_pwhash_scryptsalsa208sha256_STRPREFIX"
-    });
+                       s.ends_with("_PRIMITIVE") ||
+                       s == "crypto_pwhash_scryptsalsa208sha256_STRPREFIX"
+                   });
     cfg.generate("../rust_sodium-sys/lib.rs", "all.rs");
 }


### PR DESCRIPTION
This replaces the two different methods used to download libsodium (a Powershell command for Windows
and a curl command otherwise) with a single one implemented in Rust via the reqwest crate.