### PR TITLE
Disable PIE on systems without lsb_release

### DIFF
--- a/rust_sodium-sys/build.rs
+++ b/rust_sodium-sys/build.rs
@@ -335,7 +335,7 @@ fn main() {
                 "--disable-pie"
             }
         }
-        _ => "",
+        _ => "--disable-pie",
     };
 
     let mut configure_cmd = Command::new("./configure");


### PR DESCRIPTION
See this comment for explanation and the context:

https://github.com/maidsafe/rust_sodium/pull/34#discussion_r123076486

/cc @ffflorian, @ustulation 