### PR TITLE
Download libsodium sources using reqwest library

### DIFF
--- a/rust_sodium-sys/Cargo.toml
+++ b/rust_sodium-sys/Cargo.toml
@@ -24,10 +24,11 @@ pkg-config = { version = "~0.3.9", optional = true }
 tar = { version = "~0.4.13", optional = true }
 unwrap = "~1.1.0"
 zip = { version = "~0.2.6", optional = true }
+reqwest = { version = "^0.8", optional = true }
 
 [lib]
 path = "lib.rs"
 
 [features]
-default = ["flate2", "gcc", "tar", "zip"]
+default = ["flate2", "gcc", "tar", "zip", "reqwest"]
 use-installed-libsodium = ["pkg-config"]

--- a/rust_sodium-sys/build.rs
+++ b/rust_sodium-sys/build.rs
@@ -4,6 +4,7 @@ extern crate unwrap;
 #[cfg(feature = "use-installed-libsodium")]
 extern crate pkg_config;
 
+const DOWNLOAD_BASE_URL: &'static str = "https://download.libsodium.org/libsodium/releases/";
 const VERSION: &'static str = "1.0.12";
 
 #[cfg(feature = "use-installed-libsodium")]
@@ -84,7 +85,7 @@ fn download_compressed_file() -> String {
     } else {
         basename.clone() + "-mingw.tar.gz"
     };
-    let url = "https://download.libsodium.org/libsodium/releases/".to_string() + &zip_filename;
+    let url = format!("{}{}", DOWNLOAD_BASE_URL, zip_filename);
     let zip_path = get_install_dir() + "/" + &zip_filename;
     let mut command = "([Net.ServicePointManager]::SecurityProtocol = 'Tls12') -and \
                ((New-Object System.Net.WebClient).DownloadFile(\""
@@ -271,8 +272,7 @@ fn get_sources() -> (String, String) {
     // Download gz tarball
     let basename = "libsodium-".to_string() + VERSION;
     let gz_filename = basename.clone() + ".tar.gz";
-    let url = "https://github.com/jedisct1/libsodium/releases/download/".to_string() +
-        VERSION + "/" + &gz_filename;
+    let url = format!("{}{}", DOWNLOAD_BASE_URL, &gz_filename);
     let mut install_dir = get_install_dir();
     let mut source_dir = unwrap!(env::var("OUT_DIR")) + "/source";
     // Avoid issues with paths containing spaces by falling back to using /tmp

--- a/rust_sodium-sys/build.rs
+++ b/rust_sodium-sys/build.rs
@@ -1,8 +1,19 @@
 #[macro_use]
 extern crate unwrap;
-
 #[cfg(feature = "use-installed-libsodium")]
 extern crate pkg_config;
+#[cfg(all(not(windows), not(feature = "use-installed-libsodium")))]
+extern crate gcc;
+#[cfg(all(not(target_env = "msvc"), not(feature = "use-installed-libsodium")))]
+extern crate flate2;
+#[cfg(all(not(target_env = "msvc"), not(feature = "use-installed-libsodium")))]
+extern crate tar;
+#[cfg(all(target_env = "msvc", not(feature = "use-installed-libsodium")))]
+extern crate libc;
+#[cfg(all(target_env = "msvc", not(feature = "use-installed-libsodium")))]
+extern crate zip;
+#[cfg(not(feature = "use-installed-libsodium"))]
+extern crate reqwest;
 
 const DOWNLOAD_BASE_URL: &'static str = "https://download.libsodium.org/libsodium/releases/";
 const VERSION: &'static str = "1.0.12";
@@ -36,18 +47,32 @@ fn main() {
     }
 }
 
+/// Download the specified URL into the specified target.
+///
+/// If something fails, an error message string is returned.
+#[cfg(not(feature = "use-installed-libsodium"))]
+fn download(url: &str, target: &std::path::Path) -> Result<(), String> {
+    use std::fs::File;
+    use reqwest::Client;
 
+    // Send GET request
+    let client = Client::new();
+    let mut resp = client.get(url).send()
+        .map_err(|e| format!("Could not download: {}", e))?;
 
-#[cfg(all(not(windows), not(feature = "use-installed-libsodium")))]
-extern crate gcc;
-#[cfg(all(not(target_env = "msvc"), not(feature = "use-installed-libsodium")))]
-extern crate flate2;
-#[cfg(all(not(target_env = "msvc"), not(feature = "use-installed-libsodium")))]
-extern crate tar;
-#[cfg(all(target_env = "msvc", not(feature = "use-installed-libsodium")))]
-extern crate libc;
-#[cfg(all(target_env = "msvc", not(feature = "use-installed-libsodium")))]
-extern crate zip;
+    // Only accept 2xx status codes
+    if !resp.status().is_success() {
+        return Err(format!("Download error: HTTP {}", resp.status()))
+    }
+
+    // Write downloaded data to tempfile
+    let mut f = File::create(target)
+        .unwrap_or_else(|e| panic!("Failed to create file \"{:?}\": {}", &target, e));
+    resp.copy_to(&mut f)
+        .map_err(|e| format!("Could not write downloaded data to file: {}", e))?;
+
+    Ok(())
+}
 
 #[cfg(not(feature = "use-installed-libsodium"))]
 fn get_install_dir() -> String {
@@ -261,21 +286,27 @@ fn main() {
 
 
 /// Fetch and unpack the libsodium sources.
+///
+/// Return tuple `(source_dir, install_dir)`.
 #[cfg(all(not(windows), not(feature = "use-installed-libsodium")))]
 fn get_sources() -> (String, String) {
     use std::env;
     use std::fs::{self, File};
-    use std::process::Command;
+    use std::path::Path;
     use flate2::read::GzDecoder;
     use tar::Archive;
 
-    // Download gz tarball
-    let basename = "libsodium-".to_string() + VERSION;
-    let gz_filename = basename.clone() + ".tar.gz";
+    // Determine filenames and download URLs
+    let basename = format!("libsodium-{}", VERSION);
+    let gz_filename = format!("{}.tar.gz", basename);
     let url = format!("{}{}", DOWNLOAD_BASE_URL, &gz_filename);
+
+    // Determine source and install dir
     let mut install_dir = get_install_dir();
     let mut source_dir = unwrap!(env::var("OUT_DIR")) + "/source";
-    // Avoid issues with paths containing spaces by falling back to using /tmp
+
+    // Avoid issues with paths containing spaces by falling back to using a tempfile.
+    // See https://github.com/jedisct1/libsodium/issues/207
     let target = unwrap!(env::var("TARGET"));
     if install_dir.contains(" ") {
         let fallback_path = "/tmp/".to_string() + &basename + "/" + &target;
@@ -288,27 +319,15 @@ fn get_sources() -> (String, String) {
             fallback_path
         );
     }
-    let gz_path = source_dir.clone() + "/" + &gz_filename;
+
+    // Create directories
     unwrap!(fs::create_dir_all(&install_dir));
     unwrap!(fs::create_dir_all(&source_dir));
 
-    let mut curl_cmd = Command::new("curl");
-    let curl_output = curl_cmd
-        .arg(&url)
-        .arg("-sSLvo")
-        .arg(&gz_path)
-        .output()
-        .unwrap_or_else(|error| {
-            panic!("Failed to run curl command: {}", error);
-        });
-    if !curl_output.status.success() {
-        panic!(
-            "\n{:?}\n{}\n{}\n",
-            curl_cmd,
-            String::from_utf8_lossy(&curl_output.stdout),
-            String::from_utf8_lossy(&curl_output.stderr)
-        );
-    }
+    // Download sources
+    let gz_path = Path::new(&source_dir).join(&gz_filename);
+    download(&url, &gz_path)
+        .unwrap_or_else(|e| panic!("Download error: {}", e));
 
     // Unpack the tarball
     let gz_archive = unwrap!(File::open(&gz_path));


### PR DESCRIPTION
Instead of calling out to curl and powershell, we can use a native cross-platform HTTP client instead. This gets rid of a lot of hacky code.

May I ask why there is a fallback URL for the libsodium sources? Makes me a bit uneasy to download the sources for a crypto library in production builds from a third party (although that's fine as long as the signatures are available too).

(This cleanup will make it much easier to implement #45)