### PR TITLE
Version change to 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [0.7.0]
 - Use rust 1.22.1 stable / 2017-11-23 nightly
 - rustfmt 0.9.0 and clippy-0.0.174
+- Fixed issue in rust_sodium-sys causing libsodium to be built unoptimised on non-Windows platforms
 
 ## [0.6.0]
 - Add support for iOS build targets

--- a/rust_sodium-sys/Cargo.toml
+++ b/rust_sodium-sys/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 links = "sodium"
 name = "rust_sodium-sys"
 repository = "https://github.com/maidsafe/rust_sodium"
-version = "0.7.0"
+version = "0.7.1"
 
 [dependencies]
 lazy_static = "~0.2.9"


### PR DESCRIPTION
For non-Windows builds, if the `CFLAGS` environment variable was unset, it was being set to an empty string when calling `./configure` on libsodium.  This had the effect of switching off the default `-O2` flag when `make` was subsequently called.

This PR not only explicitly adds `-O2` to the `CFLAGS` environment variable, but ensures that unset environment variables aren't passed down to `./configure` set to empty strings.

It also takes a similar approach to the `--disable-pie` argument, although the only way in which this affected the build (i.e. passing an empty string as an argument to `./configure`) was to cause `./configure` to generate a warning in stderr.