### PR TITLE
Put 'init_with_rng' behind non-default feature gate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,11 @@ script:
     cargo fmt -- --check &&
     cargo test --release --verbose &&
     cargo test --release --verbose --manifest-path rust_sodium-sys/Cargo.toml &&
-    cargo clippy &&
-    cargo clippy --profile=test &&
-    cargo clippy --manifest-path=rust_sodium-sys/Cargo.toml &&
-    cargo clippy --profile=test --manifest-path=rust_sodium-sys/Cargo.toml
+    cargo test --release --verbose --features=seeded-rng &&
+    cargo test --release --verbose --manifest-path rust_sodium-sys/Cargo.toml --features=seeded-rng
+    cargo clippy --all-targets &&
+    cargo clippy --features=seeded-rng --all-targets &&
+    cargo clippy --manifest-path=rust_sodium-sys/Cargo.toml --all-targets &&
+    cargo clippy --manifest-path=rust_sodium-sys/Cargo.toml --features=seeded-rng --all-targets
 before_cache:
   - cargo prune

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,15 +13,16 @@ edition = "2018"
 
 [dependencies]
 libc = "~0.2.40"
-rand = "~0.4.2"
+rand = { version = "~0.4.2", optional = true }
 rust_sodium-sys = { path = "rust_sodium-sys", version = "~0.10.3" }
-serde = "~1.0.37"
+serde = "~1.0.50"
 unwrap = "~1.2.0"
 
 [dev-dependencies]
-hex = "~0.3.1"
+hex = "~0.3.2"
 rmp-serde = "~0.13.7"
-serde_json = "~1.0.13"
+serde_json = "~1.0.17"
 
 [features]
 benchmarks = []
+seeded-rng = ["rand", "rust_sodium-sys/seeded-rng"]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,4 +33,6 @@ build_script:
 test_script:
   - |-
     cargo test --verbose --release
-    cargo test --release --manifest-path rust_sodium-sys/Cargo.toml
+    cargo test --verbose --release --manifest-path rust_sodium-sys/Cargo.toml
+    cargo test --verbose --release --features=seeded-rng
+    cargo test --verbose --release --manifest-path rust_sodium-sys/Cargo.toml --features=seeded-rng

--- a/rust_sodium-sys/Cargo.toml
+++ b/rust_sodium-sys/Cargo.toml
@@ -12,18 +12,21 @@ repository = "https://github.com/maidsafe/rust_sodium"
 version = "0.10.3"
 
 [dependencies]
-lazy_static = "~1.2.0"
+lazy_static = { version = "~1.2.0", optional = true }
 libc = "~0.2.40"
-rand = "~0.4.2"
-unwrap = "~1.2.0"
+rand = { version = "~0.4.2", optional = true }
+unwrap = { version = "~1.2.0", optional = true }
 
 [build-dependencies]
-cc = "~1.0.9"
+cc = "~1.0.15"
 flate2 = "~1.0.1"
 libc = "~0.2.40"
-pkg-config = "~0.3.9"
+pkg-config = "~0.3.11"
 http_req = "~0.2.1"
-sha2 = "~0.7.0"
+sha2 = "~0.7.1"
 tar = "~0.4.15"
 unwrap = "~1.2.0"
-zip = "~0.3.1"
+zip = "~0.3.2"
+
+[features]
+seeded-rng = ["lazy_static", "rand", "unwrap"]

--- a/rust_sodium-sys/src/lib.rs
+++ b/rust_sodium-sys/src/lib.rs
@@ -58,10 +58,13 @@
 )]
 #![allow(clippy::decimal_literal_representation, clippy::unreadable_literal)]
 
+#[cfg(feature = "seeded-rng")]
 #[macro_use]
 extern crate lazy_static;
 extern crate libc;
+#[cfg(feature = "seeded-rng")]
 extern crate rand;
+#[cfg(feature = "seeded-rng")]
 #[macro_use]
 extern crate unwrap;
 
@@ -88,20 +91,24 @@ mod bindgen;
 mod seeded_rng;
 
 pub use crate::bindgen::*;
+#[cfg(feature = "seeded-rng")]
 pub use crate::seeded_rng::init_with_rng;
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "seeded-rng")))]
 mod tests {
     use super::*;
     use libc::*;
 
     #[test]
     fn generichash_statebytes() {
+        assert!(unsafe { sodium_init() } >= 0);
         assert!(unsafe { crypto_generichash_statebytes() } > 0);
     }
 
     #[test]
     fn generichash() {
+        assert!(unsafe { sodium_init() } >= 0);
+
         let mut out = [0u8; crypto_generichash_BYTES as usize];
         let m = [0u8; 64];
         let key = [0u8; crypto_generichash_KEYBYTES as usize];
@@ -123,6 +130,8 @@ mod tests {
 
     #[test]
     fn generichash_multipart() {
+        assert!(unsafe { sodium_init() } >= 0);
+
         let mut out = [0u8; crypto_generichash_BYTES as usize];
         let m = [0u8; 64];
         let key = [0u8; crypto_generichash_KEYBYTES as usize];
@@ -151,6 +160,8 @@ mod tests {
 
     #[test]
     fn generichash_blake2b() {
+        assert!(unsafe { sodium_init() } >= 0);
+
         let mut out = [0u8; crypto_generichash_blake2b_BYTES as usize];
         let m = [0u8; 64];
         let key = [0u8; crypto_generichash_blake2b_KEYBYTES as usize];
@@ -172,6 +183,8 @@ mod tests {
 
     #[test]
     fn generichash_blake2b_salt_personal() {
+        assert!(unsafe { sodium_init() } >= 0);
+
         let mut out = [0u8; crypto_generichash_blake2b_BYTES as usize];
         let m = [0u8; 64];
         let key = [0u8; crypto_generichash_blake2b_KEYBYTES as usize];
@@ -197,6 +210,8 @@ mod tests {
 
     #[test]
     fn pwhash_scryptsalsa208sha256_str() {
+        assert!(unsafe { sodium_init() } >= 0);
+
         let password = "Correct Horse Battery Staple";
         let mut hashed_password = [0; crypto_pwhash_scryptsalsa208sha256_STRBYTES as usize];
         let ret_hash = unsafe {
@@ -223,6 +238,9 @@ mod tests {
     #[rustfmt::skip]
     fn pwhash_scryptsalsa208sha256_ll_1() {
         // See https://www.tarsnap.com/scrypt/scrypt.pdf Page 16
+
+        assert!(unsafe { sodium_init() } >= 0);
+
         let password = "";
         let salt = "";
         let n = 16;
@@ -255,6 +273,9 @@ mod tests {
     #[rustfmt::skip]
     fn pwhash_scryptsalsa208sha256_ll_2() {
         // See https://www.tarsnap.com/scrypt/scrypt.pdf Page 16
+
+        assert!(unsafe { sodium_init() } >= 0);
+
         let password = "password";
         let salt = "NaCl";
         let n = 1024;
@@ -287,6 +308,9 @@ mod tests {
     #[rustfmt::skip]
     fn pwhash_scryptsalsa208sha256_ll_3() {
         // See https://www.tarsnap.com/scrypt/scrypt.pdf Page 16
+
+        assert!(unsafe { sodium_init() } >= 0);
+
         let password = "pleaseletmein";
         let salt = "SodiumChloride";
         let n = 16_384;
@@ -319,6 +343,9 @@ mod tests {
     #[rustfmt::skip]
     fn pwhash_scryptsalsa208sha256_ll_4() {
         // See https://www.tarsnap.com/scrypt/scrypt.pdf Page 16
+
+        assert!(unsafe { sodium_init() } >= 0);
+
         let password = "pleaseletmein";
         let salt = "SodiumChloride";
         let n = 1_048_576;

--- a/rust_sodium-sys/src/seeded_rng.rs
+++ b/rust_sodium-sys/src/seeded_rng.rs
@@ -7,6 +7,8 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
+#![cfg(feature = "seeded-rng")]
+
 use super::{randombytes_implementation, randombytes_set_implementation, sodium_init};
 use libc;
 use rand::{self, Rng, SeedableRng, XorShiftRng};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,8 @@
 
 #[cfg(test)]
 extern crate hex;
+#[cfg(feature = "seeded-rng")]
+extern crate rand;
 #[cfg(test)]
 extern crate rmp_serde;
 #[cfg(test)]
@@ -162,6 +164,7 @@ pub fn init() -> Result<(), ()> {
     }
 }
 
+#[cfg(feature = "seeded-rng")]
 #[allow(clippy::doc_markdown)]
 /// Sets [libsodium's `randombytes_implementation`]
 /// (https://download.libsodium.org/doc/advanced/custom_rng.html) to use a

--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.2.0"
 
 [dependencies]
 rust_sodium-sys = { path = "../rust_sodium-sys", version = "~0.10.1" }
-libc = "~0.2.38"
+libc = "~0.2.40"
 
 [build-dependencies]
 ctest = "=0.1.4"


### PR DESCRIPTION
This PR adds a single commit to #60.

Primarily it hides the [slightly dangerous `randombytes_implementation` API](https://www.privateinternetaccess.com/blog/2017/08/libsodium-v1-0-12-and-v1-0-13-security-assessment/#section_3_5_4) behind a new feature `seeded-rng` which is disabled by default.

This has the side effect of allowing the rust_sodium-sys tests to all be properly initialised, since calling `sodium_init()` inside each now doesn't conflict with the test for `init_with_rng()`.