### PR TITLE
chore/changelog: Add some entries for 0.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 ## [0.8.0]
 - Use rust 1.24.0 stable / 2018-02-05 nightly
 - rustfmt 0.9.0 and clippy-0.0.186
+- The `init()` function now returns a `Result<(), ()>` instead of a `bool`
+- Add safe bindings to `sodium_pad()` and `sodium_unpad()`
+- Make `crypto::sealedbox::SEALBYTES` public
+- Add hash check for downloaded libsodium files
 
 ## [0.7.0]
 - Use rust 1.22.1 stable / 2017-11-23 nightly


### PR DESCRIPTION
I first thought that it was just a maintenance release, but the git log reveals that there were some additions and changes :slightly_smiling_face: 