### PR TITLE
chore/dependencies: update unwrap to 1.2.0

### DIFF
--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -14,4 +14,4 @@ libc = "~0.2.38"
 
 [build-dependencies]
 ctest = "=0.1.4"
-unwrap = "~1.1.0"
+unwrap = "~1.2.0"


### PR DESCRIPTION
systest was forgotten in PR #74 