### PR TITLE
chore/dependencies: fix libc to 0.2.41

### DIFF
--- a/rust_sodium-sys/Cargo.toml
+++ b/rust_sodium-sys/Cargo.toml
@@ -20,7 +20,7 @@ unwrap = "~1.2.0"
 [build-dependencies]
 cc = "~1.0.9"
 flate2 = "~1.0.1"
-libc = "~0.2.40"
+libc = "=0.2.41"
 pkg-config = "~0.3.9"
 reqwest = "~0.8.5"
 sha2 = "~0.7.0"


### PR DESCRIPTION
With later versions of libc, we started getting the following error:
```
Err(Error { kind: Io(Custom { kind: WouldBlock, error: StringError("timed out") }), url: Some("https://download.libsodium.org/libsodium/releases/libsodium-1.0.16.tar.gz") })
```
when building rust_sodium-sys.