### PR TITLE
fix/build: import missing Read trait

### DIFF
--- a/rust_sodium-sys/build.rs
+++ b/rust_sodium-sys/build.rs
@@ -18,7 +18,7 @@ use http_req::request;
 use sha2::{Digest, Sha256};
 use std::env;
 use std::fs;
-use std::io::Cursor;
+use std::io::{Cursor, Read};
 use std::path::Path;
 
 const DOWNLOAD_BASE_URL: &'static str = "https://download.libsodium.org/libsodium/releases/";
@@ -75,7 +75,7 @@ fn download(url: &str, expected_hash: &str) -> Cursor<Vec<u8>> {
     let response = unwrap!(request::get(url));
 
     // Only accept 2xx status codes
-    if response.status_code() < 200 && response.status_code() >= 300 { 
+    if response.status_code() < 200 && response.status_code() >= 300 {
         panic!("Download error: HTTP {}", response.status_code());
     }
     let resp_body = response.body();


### PR DESCRIPTION
Building libsodium requires the `Read` trait to be imported to call the `read_to_end` function.

https://github.com/maidsafe/rust_sodium/blob/af37b943663150376676440eb9bc76c6ca9468ab/rust_sodium-sys/build.rs#L146
```
error[E0599]: no method named `read_to_end` found for type `zip::read::ZipFile<'_>` in the current scope
   --> C:\Users\***\.cargo\registry\src\github.com-1ecc6299db9ec823\rust_sodium-sys-0.10.1\build.rs:146:52
    |
146 |             assert_eq!(entry.size(), unwrap!(entry.read_to_end(&mut buffer)) as u64);
    |                                                    ^^^^^^^^^^^
    |
    = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope, perhaps add a `use` for it:
    |
17  | use std::io::Read;
    |

error: aborting due to previous error
```