### PR TITLE
Revert "rust_sodium-sys: Version change to 0.10.2"

### DIFF
--- a/rust_sodium-sys/CHANGELOG.md
+++ b/rust_sodium-sys/CHANGELOG.md
@@ -1,8 +1,5 @@
 # rust_sodium-sys - Change Log
 
-## [0.10.2]
-- add missing trait for MSVC build
-
 ## [0.10.1]
 - fix build: replace reqwest with http_req in build script
 - use rust 1.29.0 stable, drop nightly

--- a/rust_sodium-sys/Cargo.toml
+++ b/rust_sodium-sys/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 links = "sodium"
 name = "rust_sodium-sys"
 repository = "https://github.com/maidsafe/rust_sodium"
-version = "0.10.2"
+version = "0.10.1"
 
 [dependencies]
 lazy_static = "~1.0.0"


### PR DESCRIPTION
Reverts maidsafe/rust_sodium#86

Just temporarily reverting this to fix the linter issues via https://github.com/maidsafe/rust_sodium/pull/87 as part of this patch change