### PR TITLE
Fix build on rust 1.31.0

### DIFF
--- a/rust_sodium-sys/Cargo.toml
+++ b/rust_sodium-sys/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/maidsafe/rust_sodium"
 version = "0.10.2"
 
 [dependencies]
-lazy_static = "~1.0.0"
+lazy_static = "^1.1.0"
 libc = "~0.2.40"
 rand = "~0.4.2"
 unwrap = "~1.2.0"

--- a/rust_sodium-sys/src/lib.rs
+++ b/rust_sodium-sys/src/lib.rs
@@ -8,7 +8,7 @@
 )]
 #![deny(
     deprecated, improper_ctypes, non_shorthand_field_patterns, overflowing_literals,
-    plugin_as_library, private_no_mangle_fns, private_no_mangle_statics, stable_features,
+    plugin_as_library, stable_features,
     unconditional_recursion, unknown_lints, unused, unused_allocation, unused_attributes,
     unused_comparisons, unused_features, unused_parens, while_true
 )]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,8 +73,6 @@
     non_shorthand_field_patterns,
     overflowing_literals,
     plugin_as_library,
-    private_no_mangle_fns,
-    private_no_mangle_statics,
     stable_features,
     unconditional_recursion,
     unknown_lints,


### PR DESCRIPTION
Building on rust 1.31.0 fails with errors like

error: lint `private_no_mangle_fns` has been removed: `no longer an warning, #[no_mangle] functions always exported`

This PR removes the lint.