### PR TITLE
Version change to 0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # rust_sodium - Change Log
 
 ## [0.10.1]
+- upgrade rust_sodium-sys to 0.10.3
+- use stable rust, 2018 edition without being tied to
+  a specific version
+- use cargo fmt and cargo clippy
+
+## [0.10.1]
 - upgrade rust_sodium-sys to 0.10.1
 - use rust to 1.29.0 stable, drop nightly
 - use cargo fmt and cargo clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,13 @@ license = "MIT OR Apache-2.0"
 name = "rust_sodium"
 readme = "README.md"
 repository = "https://github.com/maidsafe/rust_sodium"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2018"
 
 [dependencies]
 libc = "~0.2.40"
 rand = "~0.4.2"
-rust_sodium-sys = { path = "rust_sodium-sys", version = "~0.10.1" }
+rust_sodium-sys = { path = "rust_sodium-sys", version = "~0.10.3" }
 serde = "~1.0.37"
 unwrap = "~1.2.0"
 

--- a/rust_sodium-sys/CHANGELOG.md
+++ b/rust_sodium-sys/CHANGELOG.md
@@ -1,5 +1,9 @@
 # rust_sodium-sys - Change Log
 
+## [0.10.3]
+- update lazy_static to 1.2.0
+- fix compilation with rustc 1.32.0
+
 ## [0.10.2]
 - add missing trait for MSVC build
 

--- a/rust_sodium-sys/Cargo.toml
+++ b/rust_sodium-sys/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 links = "sodium"
 name = "rust_sodium-sys"
 repository = "https://github.com/maidsafe/rust_sodium"
-version = "0.10.2"
+version = "0.10.3"
 
 [dependencies]
 lazy_static = "~1.2.0"


### PR DESCRIPTION
Somehow rust_sodium-sys was updated to 0.10.2 but rust_sodium was still
using version 0.10.1.