### PR TITLE
Fix redundent import of hex

### DIFF
--- a/src/crypto/hash/sha256.rs
+++ b/src/crypto/hash/sha256.rs
@@ -64,7 +64,6 @@ mod test {
     }
 
     fn test_nist_vector(filename: &str) {
-        use hex;
         use std::fs::File;
         use std::io::{BufRead, BufReader};
 

--- a/src/crypto/hash/sha512.rs
+++ b/src/crypto/hash/sha512.rs
@@ -52,7 +52,6 @@ mod test {
     }
 
     fn test_nist_vector(filename: &str) {
-        use hex;
         use std::fs::File;
         use std::io::{BufRead, BufReader};
 


### PR DESCRIPTION
Assuming there was change from edition 2015 to edition 2018 that
triggered this, as it made the import `use hex` redundent, due to
changes to import path behaviour.

Removed the use statement and the tests all run and pass now.