### PR TITLE
chore/deps: update lazy_static

### DIFF
--- a/rust_sodium-sys/Cargo.toml
+++ b/rust_sodium-sys/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/maidsafe/rust_sodium"
 version = "0.10.4"
 
 [dependencies]
-lazy_static = "~1.2.0"
+lazy_static = "^1"
 libc = "~0.2.40"
 rand = "~0.4.2"
 unwrap = "~1.2.0"


### PR DESCRIPTION
Change dependency to semantic versioning. The previous version specifier only allowed versions 1.2.x, which breaks compilation if another project requires ^1.3.

Version 1.x should be safe since that's what was used before #95.

See https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#tilde-requirements

(This is currently blocking me from updating other dependencies in a project that also uses rust_sodium...)